### PR TITLE
Refine/event event tiles

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,7 @@ key:
 	+ Don't show attendees button unless their guest status is either %registered or %attended, or they're the host. Also we should rename the buttons to "guest list"
 	+ Timeline: visually distinguish between record and event
 	+ Should see our record status on event page and include the status change button in here instead of on the timeline card.
-		- The entire event/record tiles on the Timeline page should be clickable, opening the event details.
+		+ The entire event/record tiles on the Timeline page should be clickable, opening the event details.
 	- Remove matching functions from guest list
 	- General button feedback so user knows when an action succeeds/fails (e.g. when the profile is updated, the form closes; if it fails they get an error message)
 	- Mobile menu button adjustments (see ~sarlev's feedback)

--- a/todo.md
+++ b/todo.md
@@ -10,7 +10,7 @@ key:
 ## Refinements
 	+ Don't show attendees button unless their guest status is either %registered or %attended, or they're the host. Also we should rename the buttons to "guest list"
 	+ Timeline: visually distinguish between record and event
-	- Should see our record status on event page and include the status change button in here instead of on the timeline card.
+	+ Should see our record status on event page and include the status change button in here instead of on the timeline card.
 		- The entire event/record tiles on the Timeline page should be clickable, opening the event details.
 	- Remove matching functions from guest list
 	- General button feedback so user knows when an action succeeds/fails (e.g. when the profile is updated, the form closes; if it fails they get an error message)

--- a/todo.md
+++ b/todo.md
@@ -9,7 +9,7 @@ key:
 
 ## Refinements
 	+ Don't show attendees button unless their guest status is either %registered or %attended, or they're the host. Also we should rename the buttons to "guest list"
-	- Timeline: visually distinguish between record and event
+	+ Timeline: visually distinguish between record and event
 	- Should see our record status on event page and include the status change button in here instead of on the timeline card.
 		- The entire event/record tiles on the Timeline page should be clickable, opening the event details.
 	- Remove matching functions from guest list

--- a/ui/.env.template
+++ b/ui/.env.template
@@ -1,1 +1,2 @@
 VITE_SHIP_URL=http://localhost:8080
+VITE_ENABLE_PWA_IN_DEV=false

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-navigation-menu": "^1.2.0",
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tabs": "^1.1.1",
         "@urbit/api": "^2.3.0",
         "@urbit/http-api": "^2.3.0",
         "class-variance-authority": "^0.7.0",
@@ -2653,6 +2654,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
+      "integrity": "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.1.tgz",
@@ -2708,6 +2739,72 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.1.tgz",
+      "integrity": "sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "vite dev",
     "build": "tsc && vite build",
     "serve": "vite preview",
     "test": "tsc --noEmit",
@@ -17,6 +17,7 @@
     "@radix-ui/react-navigation-menu": "^1.2.0",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.1",
     "@urbit/api": "^2.3.0",
     "@urbit/http-api": "^2.3.0",
     "class-variance-authority": "^0.7.0",

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -307,63 +307,6 @@ const allRecordsSchema = z.object({
     ))
 }).transform((response) => response.allRecords)
 
-
-function backendRecordToEvent(eventId: EventId, record: z.infer<typeof backendRecordSchema>): Event {
-  const {
-    info: {
-      moment: { start, end },
-      about,
-      location: _location,
-      timezone,
-      group: _group,
-      sessions: _sessions,
-      ...infoRest
-    },
-    status: { p: eventStatus, q: _inviteTime },
-    secret: _ } = record
-
-  return {
-    id: eventId,
-    description: (about ? about : "no event description"),
-    startDate: (start ? new Date(start) : new Date(0)),
-    endDate: (end ? new Date(end) : new Date(0)),
-    status: eventStatus,
-    location: (_location ? _location : "no location"),
-    group: (_group ? _group : "no group"),
-    timezone: "TBD",
-    sessions: [
-      {
-        title: "first talk",
-        mainSpeaker: "~sampel-palnet",
-        panel: [],
-        location: "anywhere",
-        about: "idk just vibes",
-        startTime: new Date(1995, 11, 17, 3, 13, 37),
-        endTime: new Date(1995, 11, 17, 3, 16, 20),
-      },
-      {
-        title: "second talk",
-        mainSpeaker: "~sampel-palnet",
-        panel: ["~sampel-palnet", "~sampel-palnet"],
-        location: "anywhere",
-        about: "idk just vibes",
-        startTime: new Date(1995, 11, 17, 3, 13, 37),
-        endTime: new Date(1995, 11, 17, 3, 16, 20),
-      },
-      {
-        title: "third talk",
-        mainSpeaker: "~sampel-palnet",
-        panel: ["~sampel-palnet", "~sampel-palnet", "~sampel-palnet"],
-        location: "anywhere",
-        about: "idk just vibes",
-        startTime: new Date(1995, 11, 18, 3, 13, 37),
-        endTime: new Date(1995, 11, 18, 3, 16, 20),
-      }
-    ],
-    ...infoRest
-  }
-}
-
 function getRecords(api: Urbit, ship: string): () => Promise<EventAsGuest[]> {
   return async () => {
     const allRecords = await api.scry({

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -13,10 +13,16 @@ interface Backend {
   // --- live agent --- //
 
   // live - scry %all-records
-  getEvents(): Promise<Event[]>
+  getRecords(): Promise<EventAsGuest[]>
 
   // live - scry %record
-  getEvent(id: EventId): Promise<Event>
+  getRecord(id: EventId): Promise<EventAsGuest>
+
+  // live - scry %all-events
+  getEvents(): Promise<EventAsHost[]>
+
+  // live - scry %event
+  getEvent(id: EventId): Promise<EventAsHost>
 
   // live - poke %register
   register(id: EventId): Promise<void>
@@ -87,6 +93,12 @@ type Session = {
   endTime: Date;
 }
 
+// TODO:
+// split into:
+// EventDetails: current event
+// EventAsGuest: EventDetails & EventStatus & {secret: string}
+// EventAsHost: EventDetails & {secret: string | null, limit: number | null}
+
 type Event = {
   id: EventId;
   status: EventStatus;  // we also have invitation date if we want
@@ -101,7 +113,34 @@ type Event = {
   sessions: Session[]
 }
 
-const emptyEvent: Event = {
+
+type EventDetails = {
+  id: EventId;
+  location: string;
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+  description: string;
+  group: string;
+  kind: "public" | "private" | "secret";
+  latch: "open" | "closed" | "over";
+  sessions: Session[]
+}
+
+type EventAsHost = {
+  secret: string | null,
+  limit: number | null,
+  details: EventDetails
+}
+
+type EventAsGuest = {
+  secret: string | null,
+  status: EventStatus,
+  details: EventDetails
+}
+
+
+const emptyEventDetails: Event = {
   id: {
     ship: "",
     name: "",
@@ -118,9 +157,22 @@ const emptyEvent: Event = {
   sessions: []
 }
 
+
+const emptyEventAsGuest: EventAsGuest = {
+  secret: "",
+  status: "" as EventStatus,
+  details: emptyEventDetails
+}
+
+const emptyEventAsHost: EventAsHost = {
+  secret: "",
+  limit: 0,
+  details: emptyEventDetails
+}
+
 type LiveUpdateEvent = {
   ship: string,
-  event: Event,
+  event: EventDetails,
 }
 
 // function getSchedule(_api: Urbit): () => Promise<Session[]> {
@@ -149,25 +201,94 @@ const eventLatchSchema = z.enum([
 
 const timeSchema = z.number()
 
-const recordSchema = z.object({
-  info: z.object({
-    about: z.string().nullable(),
-    group: z.string().nullable(),
-    kind: eventVisibilitySchema,
-    latch: eventLatchSchema,
-    location: z.string().nullable(),
-    moment: z.object({ start: timeSchema.nullable(), end: timeSchema.nullable() }),
-    sessions: z.object({}).catchall(z.any()),
-    timezone: z.object({ p: z.boolean(), q: z.number() }),
-    title: z.string(),
-    ["venue-map"]: z.string().nullable(),
-  }),
+const backendInfo1Schema = z.object({
+  about: z.string().nullable(),
+  group: z.string().nullable(),
+  kind: eventVisibilitySchema,
+  latch: eventLatchSchema,
+  location: z.string().nullable(),
+  moment: z.object({ start: timeSchema.nullable(), end: timeSchema.nullable() }),
+  sessions: z.object({}).catchall(z.any()),
+  timezone: z.object({ p: z.boolean(), q: z.number() }),
+  title: z.string(),
+  ["venue-map"]: z.string().nullable(),
+})
+
+
+function backendInfo1ToEventDetails(eventId: EventId, info1: z.infer<typeof backendInfo1Schema>): EventDetails {
+  const {
+    moment: { start, end },
+    about,
+    location: _location,
+    timezone,
+    group: _group,
+    sessions: _sessions,
+    ...infoRest
+  } = info1
+
+  return {
+    id: eventId,
+    description: (about ? about : "no event description"),
+    startDate: (start ? new Date(start) : new Date(0)),
+    endDate: (end ? new Date(end) : new Date(0)),
+    location: (_location ? _location : "no location"),
+    group: (_group ? _group : "no group"),
+    timezone: "TBD",
+    sessions: [
+      {
+        title: "first talk",
+        mainSpeaker: "~sampel-palnet",
+        panel: [],
+        location: "anywhere",
+        about: "idk just vibes",
+        startTime: new Date(1995, 11, 17, 3, 13, 37),
+        endTime: new Date(1995, 11, 17, 3, 16, 20),
+      },
+      {
+        title: "second talk",
+        mainSpeaker: "~sampel-palnet",
+        panel: ["~sampel-palnet", "~sampel-palnet"],
+        location: "anywhere",
+        about: "idk just vibes",
+        startTime: new Date(1995, 11, 17, 3, 13, 37),
+        endTime: new Date(1995, 11, 17, 3, 16, 20),
+      },
+      {
+        title: "third talk",
+        mainSpeaker: "~sampel-palnet",
+        panel: ["~sampel-palnet", "~sampel-palnet", "~sampel-palnet"],
+        location: "anywhere",
+        about: "idk just vibes",
+        startTime: new Date(1995, 11, 18, 3, 13, 37),
+        endTime: new Date(1995, 11, 18, 3, 16, 20),
+      }
+    ],
+    ...infoRest
+  }
+}
+
+const backendRecordSchema = z.object({
+  info: backendInfo1Schema,
   secret: z.string().nullable(),
   status: z.object({
     p: eventStatusSchema,
     q: timeSchema
   })
 })
+
+function backendRecordToEventAsGuest(eventId: EventId, record: z.infer<typeof backendRecordSchema>): EventAsGuest {
+  const {
+    info,
+    status: { p: eventStatus, q: _inviteTime },
+    secret: _
+  } = record
+
+  return {
+    secret: "",
+    status: eventStatus,
+    details: backendInfo1ToEventDetails(eventId, info)
+  }
+}
 
 // const allRecordsSchema = z.object({
 //   allRecords: z.object({})    
@@ -179,114 +300,15 @@ const recordSchema = z.object({
 
 const allRecordsSchema = z.object({
   allRecords: z.record(
-    z.string(), // this is going to be `${hostShip} ${eventName}`
+    z.string(), // this is going to be `${hostShip}/${eventName}`
     z.record(
-      z.string(), // this is `${guesShip}`
-      z.object({ record: recordSchema })
+      z.string(), // this is `${guestShip}`
+      z.object({ record: backendRecordSchema })
     ))
-})
+}).transform((response) => response.allRecords)
 
-// const events = api.scry({
-//   app: "live",
-//   path: "/events/all"
-// }).then((res) => {
-//   // const result = allRecordsSchema.parse(res)
-//   // console.log("parsed records: ",result)
-// })
-//
-//[
-//      {
-//        id: {
-//          ship: "~sampel-palnet",
-//          name: "my-event",
-//        },
-//        status: "invited",
-//        location: "atlantis",
-//        startDate: new Date(1300000000000),
-//        endDate: new Date(1400000000000),
-//        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam posuere ultrices porttitor. Curabitur interdum, ante nec pellentesque aliquam, mi ante facilisis ex, et condimentum quam sapien sit amet arcu. Praesent gravida iaculis auctor. Maecenas convallis eu magna lacinia tincidunt. Curabitur eget vehicula lorem, non elementum est. Fusce nec tristique lectus. Aenean nisi elit, suscipit nec bibendum iaculis, porttitor quis purus. Proin fermentum nunc nec massa facilisis pretium. Nulla fermentum ultrices sapien, vel facilisis nisi consequat et. Pellentesque sagittis nunc ligula, nec lacinia mauris egestas vel. Donec eu tincidunt erat. Etiam facilisis consectetur consectetur. Aliquam erat volutpat. Suspendisse condimentum at neque nec aliquam. Nunc malesuada feugiat arcu vitae accumsan. Phasellus id sapien quam. Donec eu lorem lobortis, ullamcorper nisl in, tempor ante. Etiam rhoncus luctus metus ac mattis. Pellentesque ullamcorper erat id diam vestibulum porta suscipit non erat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus, lectus sit amet facilisis mollis, sapien mi suscipit metus, ut egestas metus nunc eget ipsum. Nulla in feugiat ante. Vestibulum vitae tellus eu dolor efficitur pretium sed vitae massa. Nullam quis vehicula nisl, sed tempus dolor. Mauris tristique arcu nec sagittis tincidunt. Aenean commodo urna blandit nulla vulputate porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec ipsum turpis, tristique vitae nisl facilisis, pretium facilisis nibh. Maecenas aliquet dignissim bibendum. Cras non aliquet ipsum. Donec pulvinar varius neque, sed feugiat eros aliquet quis. Donec non lacinia lorem. ",
-//        timezone: "PST",
-//        kind: "public",
-//        group: "~sampel-palnet/my-event",
-//        latch: "open",
-//        sessions: [
-//          {
-//            title: "First talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: [],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 17, 3, 13, 37),
-//            endTime: new Date(1995, 11, 17, 3, 16, 20),
-//          },
-//          {
-//            title: "Second talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: ["~sampel-palnet", "~sampel-palnet"],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 17, 3, 13, 37),
-//            endTime: new Date(1995, 11, 17, 3, 16, 20),
-//          },
-//          {
-//            title: "Third talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: ["~sampel-palnet", "~sampel-palnet", "~sampel-palnet"],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 18, 3, 13, 37),
-//            endTime: new Date(1995, 11, 18, 3, 16, 20),
-//          }
-//        ]
-//      },
-//      {
-//        id: {
-//          ship: "~sampel-palnet",
-//          name: "my-event-2",
-//        },
-//        status: "registered",
-//        location: "atlantis",
-//        startDate: new Date(1300000000000),
-//        endDate: new Date(1400000000000),
-//        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam posuere ultrices porttitor. Curabitur interdum, ante nec pellentesque aliquam, mi ante facilisis ex, et condimentum quam sapien sit amet arcu. Praesent gravida iaculis auctor. Maecenas convallis eu magna lacinia tincidunt. Curabitur eget vehicula lorem, non elementum est. Fusce nec tristique lectus. Aenean nisi elit, suscipit nec bibendum iaculis, porttitor quis purus. Proin fermentum nunc nec massa facilisis pretium. Nulla fermentum ultrices sapien, vel facilisis nisi consequat et. Pellentesque sagittis nunc ligula, nec lacinia mauris egestas vel. Donec eu tincidunt erat. Etiam facilisis consectetur consectetur. Aliquam erat volutpat. Suspendisse condimentum at neque nec aliquam. Nunc malesuada feugiat arcu vitae accumsan. Phasellus id sapien quam. Donec eu lorem lobortis, ullamcorper nisl in, tempor ante. Etiam rhoncus luctus metus ac mattis. Pellentesque ullamcorper erat id diam vestibulum porta suscipit non erat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus, lectus sit amet facilisis mollis, sapien mi suscipit metus, ut egestas metus nunc eget ipsum. Nulla in feugiat ante. Vestibulum vitae tellus eu dolor efficitur pretium sed vitae massa. Nullam quis vehicula nisl, sed tempus dolor. Mauris tristique arcu nec sagittis tincidunt. Aenean commodo urna blandit nulla vulputate porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec ipsum turpis, tristique vitae nisl facilisis, pretium facilisis nibh. Maecenas aliquet dignissim bibendum. Cras non aliquet ipsum. Donec pulvinar varius neque, sed feugiat eros aliquet quis. Donec non lacinia lorem. ",
-//        timezone: "PST",
-//        kind: "public",
-//        group: "~sampel-palnet/my-event",
-//        latch: "open",
-//        sessions: [
-//          {
-//            title: "First talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: [],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 17, 3, 13, 37),
-//            endTime: new Date(1995, 11, 17, 3, 16, 20),
-//          },
-//          {
-//            title: "Second talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: ["~sampel-palnet", "~sampel-palnet"],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 17, 3, 13, 37),
-//            endTime: new Date(1995, 11, 17, 3, 16, 20),
-//          },
-//          {
-//            title: "Third talk",
-//            mainSpeaker: "~sampel-palnet",
-//            panel: ["~sampel-palnet", "~sampel-palnet", "~sampel-palnet"],
-//            location: "anywhere",
-//            about: "idk just vibes",
-//            startTime: new Date(1995, 11, 18, 3, 13, 37),
-//            endTime: new Date(1995, 11, 18, 3, 16, 20),
-//          }
-//        ]
-//      }
-//    ]
-//
 
-function backendRecordToEvent(eventId: EventId, record: z.infer<typeof recordSchema>): Event {
+function backendRecordToEvent(eventId: EventId, record: z.infer<typeof backendRecordSchema>): Event {
   const {
     info: {
       moment: { start, end },
@@ -342,14 +364,14 @@ function backendRecordToEvent(eventId: EventId, record: z.infer<typeof recordSch
   }
 }
 
-function getEvents(api: Urbit, ship: string): () => Promise<Event[]> {
+function getRecords(api: Urbit, ship: string): () => Promise<EventAsGuest[]> {
   return async () => {
     const allRecords = await api.scry({
       app: "live",
       path: "/records/all"
     })
       .then(allRecordsSchema.parse)
-      .catch((err) => { console.error("error during getEvents api call", err) })
+      .catch((err) => { console.error("error during getRecords api call", err) })
 
     if (!allRecords) {
       return Promise.resolve([])
@@ -357,31 +379,30 @@ function getEvents(api: Urbit, ship: string): () => Promise<Event[]> {
 
     // console.log("parsed records: ", allRecords)
 
-    const allRecordsToEvents = (records: z.infer<typeof allRecordsSchema>): Event[] => {
+    const allRecordsToEvents = (records: z.infer<typeof allRecordsSchema>): EventAsGuest[] => {
 
       const allRecords = Object.
-        entries(records.allRecords).
+        entries(records).
         filter(([idString,]) => {
           console.log(idString, ship)
           const [hostShip,] = idString.split("/")
           return hostShip !== "~" + ship
         }).
-        map(([idString, records]): Event => {
+        map(([idString, records]): EventAsGuest => {
           const [hostShip, eventName] = idString.split("/")
           const eventId = { ship: hostShip, name: eventName }
 
           if (Object.keys(records).length < 1) {
             console.error("records has less than one key: ", records)
-            return emptyEvent
+            return emptyEventAsGuest
           }
 
           if (Object.keys(records).length > 1) {
             console.error("records has more than one key: ", records)
-            return emptyEvent
+            return emptyEventAsGuest
           }
 
-          const record = Object.values(records)[0]
-          return backendRecordToEvent(eventId, record.record)
+          return backendRecordToEventAsGuest(eventId, Object.values(records)[0].record)
         })
       // console.log(allRecords)
       return allRecords
@@ -392,21 +413,105 @@ function getEvents(api: Urbit, ship: string): () => Promise<Event[]> {
   }
 }
 
-function getEvent(api: Urbit, ship: string): (id: EventId) => Promise<Event> {
+function getRecord(api: Urbit, ship: string): (id: EventId) => Promise<EventAsGuest> {
   return async (id: EventId) => {
     const record = await api.scry({
       app: "live",
       path: `/record/${id.ship}/${id.name}/~${ship}`
     })
-      .then(z.object({ record: recordSchema }).parse)
-      .catch((err) => { console.error("error during getEvent api call", err) })
+      .then(z.object({ record: backendRecordSchema }).parse)
+      .catch((err) => { console.error("error during getRecord api call", err) })
 
 
     if (!record) {
-      return Promise.resolve(emptyEvent)
+      return Promise.resolve(emptyEventAsGuest)
     }
 
-    return backendRecordToEvent(id, record.record)
+    return backendRecordToEventAsGuest(id, record.record)
+  }
+}
+
+
+const backendEventSchema = z.object({
+  info: backendInfo1Schema,
+  secret: z.string().nullable(),
+  limit: z.number().nullable(),
+})
+
+function backendEventToEventAsHost(eventId: EventId, event: z.infer<typeof backendEventSchema>): EventAsHost {
+  const {
+    info,
+    limit,
+    secret
+  } = event
+
+  return {
+    details: backendInfo1ToEventDetails(eventId, info),
+    secret,
+    limit
+  }
+}
+
+const allEventsSchema = z.object({
+  allEvents: z.record(
+    z.string(), // this is going to be `${hostShip}/${eventName}`
+    z.object({ event: backendEventSchema }))
+}).transform(({ allEvents }) => allEvents)
+
+
+function getEvents(api: Urbit): () => Promise<EventAsHost[]> {
+  return async () => {
+    const allEvents = await api.scry({
+      app: "live",
+      path: "/events/all"
+    })
+      .then(allEventsSchema.parse)
+      .catch((err) => { console.error("error during getEvents api call", err) })
+
+    if (!allEvents) {
+      return Promise.resolve([])
+    }
+
+    console.log("parsed events: ", allEvents)
+
+    const allBackendEventsToEvents = (events: z.infer<typeof allEventsSchema>): EventAsHost[] => {
+
+      const allRecords = Object.
+        entries(events).
+        // filter(([idString,]) => {
+        //   console.log(idString, ship)
+        //   const [hostShip,] = idString.split("/")
+        //   return hostShip !== "~" + ship
+        // }).
+        map(([idString, { event }]): EventAsHost => {
+          const [hostShip, eventName] = idString.split("/")
+          const eventId = { ship: hostShip, name: eventName }
+
+          return backendEventToEventAsHost(eventId, event)
+        })
+      // console.log(allRecords)
+      return allRecords
+    }
+
+
+    return allBackendEventsToEvents(allEvents)
+  }
+}
+
+function getEvent(api: Urbit): (id: EventId) => Promise<EventAsHost> {
+  return async (id: EventId) => {
+    const event = await api.scry({
+      app: "live",
+      path: `/event/${id.ship}/${id.name}`
+    })
+      .then(z.object({ event: backendEventSchema }).parse)
+      .catch((err) => { console.error("error during getEvent api call", err) })
+
+    if (!event) {
+      return Promise.resolve(emptyEventAsHost)
+    }
+
+    return backendEventToEventAsHost(id, event.event)
   }
 }
 
@@ -448,7 +553,7 @@ const liveUpdateEventSchema = z.object({
     ship: z.string(),
   }),
   ship: z.string(),
-  record: recordSchema,
+  record: backendRecordSchema,
 })
 
 
@@ -697,8 +802,10 @@ function newBackend(api: Urbit, ship: string): Backend {
     register: register(api),
     unregister: unregister(api),
     // getSchedule: getSchedule(api),
-    getEvents: getEvents(api, ship),
-    getEvent: getEvent(api, ship),
+    getRecords: getRecords(api, ship),
+    getRecord: getRecord(api, ship),
+    getEvents: getEvents(api),
+    getEvent: getEvent(api),
     subscribeToLiveEvents: subscribeToLiveEvents(api),
 
     getProfile: getProfile(api),
@@ -717,4 +824,4 @@ function newBackend(api: Urbit, ship: string): Backend {
 
 export { newBackend, eventIdsEqual }
 
-export type { EventId, Event, Session, Attendee, Profile, Backend }
+export type { EventId, Event, EventAsGuest, EventAsHost, EventDetails, Session, Attendee, Profile, Backend }

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -172,7 +172,7 @@ const emptyEventAsHost: EventAsHost = {
 
 type LiveUpdateEvent = {
   ship: string,
-  event: EventDetails,
+  event: EventAsGuest,
 }
 
 // function getSchedule(_api: Urbit): () => Promise<Session[]> {
@@ -568,10 +568,9 @@ function subscribeToLiveEvents(_api: Urbit): (handlers: {
       app: "live",
       path: "/updates",
       event: (evt) => {
-        console.log("here is one vent ", evt)
         const updateEvent = liveUpdateEventSchema.parse(evt)
         onEvent({
-          event: backendRecordToEvent(updateEvent.id, updateEvent.record),
+          event: backendRecordToEventAsGuest(updateEvent.id, updateEvent.record),
           ship: updateEvent.ship
         })
       },
@@ -824,4 +823,4 @@ function newBackend(api: Urbit, ship: string): Backend {
 
 export { newBackend, eventIdsEqual }
 
-export type { EventId, Event, EventAsGuest, EventAsHost, EventDetails, Session, Attendee, Profile, Backend }
+export type { EventId, Event, EventStatus, EventAsGuest, EventAsHost, EventDetails, Session, Attendee, Profile, Backend }

--- a/ui/src/components/event-list.tsx
+++ b/ui/src/components/event-list.tsx
@@ -17,20 +17,23 @@ const ListItem: React.FC<
   // forward, add an icon in a button
   return (
     <li className="my-5">
-      <Card>
-        <CardHeader>
-          <CardTitle className="font-medium hover:font-bold">
-            <Link to={`event/${ship}/${name}`}> {name} </Link>
-          </CardTitle>
-          <CardDescription className="italics">hosted by {ship}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p>Starts on {startDate.toDateString()}</p>
-          <p>location: {location}</p>
-        </CardContent>
-        <CardFooter>
-        </CardFooter>
-      </Card>
+
+      <Link to={`event/${ship}/${name}`}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-medium hover:font-bold">
+              {name}
+            </CardTitle>
+            <CardDescription className="italics">hosted by {ship}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p>Starts on {startDate.toDateString()}</p>
+            <p>location: {location}</p>
+          </CardContent>
+          <CardFooter>
+          </CardFooter>
+        </Card>
+      </Link>
     </li>
   )
 }

--- a/ui/src/components/event-list.tsx
+++ b/ui/src/components/event-list.tsx
@@ -7,17 +7,22 @@ import {
   CardTitle
 } from "@/components/ui/card"
 
-import { Backend, Event } from "@/backend"
+import { Backend, EventAsGuest, EventDetails } from "@/backend"
 import { Link } from "react-router-dom"
 import { Button } from "./ui/button"
 
-interface FnProps {
+
+
+type FnProps = {
   register: Backend["register"]
   unregister: Backend["unregister"]
 }
 
-const EventButtons: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns }) => {
-  switch (evt.status) {
+const EventButtons: React.FC<
+  { event: EventAsGuest; }
+  & FnProps
+> = ({ event: { details: { id: eventId }, status, secret: _secret }, ...fns }) => {
+  switch (status) {
     case "invited":
     case "unregistered":
       return (
@@ -26,7 +31,7 @@ const EventButtons: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns
             className="h-full w-full"
             onClick={
               () => {
-                fns.register(evt.id)
+                fns.register(eventId)
               }}
           > register </Button>
         </div>
@@ -38,8 +43,8 @@ const EventButtons: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns
           <Button
             className="h-full w-full hover:bg-red-900"
             onClick={() => {
-              fns.unregister(evt.id).then(() => {
-                console.log("unregistered from event: ", evt.id)
+              fns.unregister(eventId).then(() => {
+                console.log("unregistered from event: ", eventId)
               })
             }}
           > unregister </Button>
@@ -64,14 +69,15 @@ const EventButtons: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns
         </div>
       )
     default:
-      console.error(`unexpected evt status: ${evt.status}`)
+      console.error(`unexpected evt status: ${status}`)
       return (<div></div>)
   }
 }
 
-const ListItem: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns }) => {
-  const { id: { ship, name } } = evt
-  console.log("e ", evt)
+const ListItem: React.FC<
+  { details: EventDetails }
+  & FnProps
+> = ({ details: { id: { ship, name }, startDate, location, ...restDetails }, ...fns }) => {
   // TODO: on mobile it's not clear that you can click the title to navigate
   // forward, add an icon in a button
   return (
@@ -84,15 +90,19 @@ const ListItem: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns }) 
           <CardDescription className="italics">hosted by {ship}</CardDescription>
         </CardHeader>
         <CardContent>
-          <p>Starts on {evt.startDate.toDateString()}</p>
-          <p>location: {evt.location}</p>
+          <p>Starts on {startDate.toDateString()}</p>
+          <p>location: {location}</p>
         </CardContent>
         <CardFooter>
-          <EventButtons
-            event={evt}
+          {/*          <EventButtons
+            event={{
+              details:
+                { id: { ship, name }, startDate, location, ...restDetails },
+              ...restEvent
+            }}
             register={fns.register}
             unregister={fns.unregister}
-          />
+          /> */}
         </CardFooter>
       </Card>
     </li>
@@ -100,7 +110,10 @@ const ListItem: React.FC<{ event: Event } & FnProps> = ({ event: evt, ...fns }) 
 }
 
 
-const EventList: React.FC<{ events: Event[] } & FnProps> = ({ events, ...fns }) => {
+const EventList: React.FC<
+  { details: EventDetails[] }
+  & FnProps
+> = ({ details: events, ...fns }) => {
   return (
     <ul>
       {/* this works, but is barely readable */}
@@ -108,7 +121,7 @@ const EventList: React.FC<{ events: Event[] } & FnProps> = ({ events, ...fns }) 
       {events.map((evt) =>
         <ListItem
           key={`${evt.id.ship}-${evt.id.name}`}
-          event={evt}
+          details={evt}
           register={fns.register}
           unregister={fns.unregister}
         />)}

--- a/ui/src/components/event-list.tsx
+++ b/ui/src/components/event-list.tsx
@@ -7,77 +7,12 @@ import {
   CardTitle
 } from "@/components/ui/card"
 
-import { Backend, EventAsGuest, EventDetails } from "@/backend"
+import { EventDetails } from "@/backend"
 import { Link } from "react-router-dom"
-import { Button } from "./ui/button"
-
-
-
-type FnProps = {
-  register: Backend["register"]
-  unregister: Backend["unregister"]
-}
-
-const EventButtons: React.FC<
-  { event: EventAsGuest; }
-  & FnProps
-> = ({ event: { details: { id: eventId }, status, secret: _secret }, ...fns }) => {
-  switch (status) {
-    case "invited":
-    case "unregistered":
-      return (
-        <div className="flex-auto">
-          <Button
-            className="h-full w-full"
-            onClick={
-              () => {
-                fns.register(eventId)
-              }}
-          > register </Button>
-        </div>
-      )
-    case "registered":
-      // TODO: add a slide-out thingy that says: arte you sure?
-      return (
-        <div className="flex-auto">
-          <Button
-            className="h-full w-full hover:bg-red-900"
-            onClick={() => {
-              fns.unregister(eventId).then(() => {
-                console.log("unregistered from event: ", eventId)
-              })
-            }}
-          > unregister </Button>
-        </div>
-      )
-    case "attended":
-      return (
-        <div className="flex-auto">
-          <Button
-            className="h-full w-full hover:bg-emerald-900"
-            disabled
-          > attended </Button>
-        </div>
-      )
-    case "requested":
-      return (
-        <div className="flex-auto">
-          <Button
-            disabled
-            className="h-full w-full hover:bg-stone-900"
-          > requested </Button>
-        </div>
-      )
-    default:
-      console.error(`unexpected evt status: ${status}`)
-      return (<div></div>)
-  }
-}
 
 const ListItem: React.FC<
   { details: EventDetails }
-  & FnProps
-> = ({ details: { id: { ship, name }, startDate, location, ...restDetails }, ...fns }) => {
+> = ({ details: { id: { ship, name }, startDate, location, ...restDetails } }) => {
   // TODO: on mobile it's not clear that you can click the title to navigate
   // forward, add an icon in a button
   return (
@@ -94,15 +29,6 @@ const ListItem: React.FC<
           <p>location: {location}</p>
         </CardContent>
         <CardFooter>
-          {/*          <EventButtons
-            event={{
-              details:
-                { id: { ship, name }, startDate, location, ...restDetails },
-              ...restEvent
-            }}
-            register={fns.register}
-            unregister={fns.unregister}
-          /> */}
         </CardFooter>
       </Card>
     </li>
@@ -112,8 +38,7 @@ const ListItem: React.FC<
 
 const EventList: React.FC<
   { details: EventDetails[] }
-  & FnProps
-> = ({ details: events, ...fns }) => {
+> = ({ details: events }) => {
   return (
     <ul>
       {/* this works, but is barely readable */}
@@ -122,8 +47,6 @@ const EventList: React.FC<
         <ListItem
           key={`${evt.id.ship}-${evt.id.name}`}
           details={evt}
-          register={fns.register}
-          unregister={fns.unregister}
         />)}
     </ul>
   )

--- a/ui/src/components/event-status-buttons.tsx
+++ b/ui/src/components/event-status-buttons.tsx
@@ -20,10 +20,7 @@ const ButtonSwitch: React.FC<
         <div className="flex-auto">
           <Button
             className="h-full w-full"
-            onClick={
-              () => {
-                fns.register(id)
-              }}
+            onClick={() => { fns.register(id) }}
           > register </Button>
         </div>
       )
@@ -33,11 +30,7 @@ const ButtonSwitch: React.FC<
         <div className="flex-auto">
           <Button
             className="h-full w-full hover:bg-red-900"
-            onClick={() => {
-              fns.unregister(id).then(() => {
-                console.log("unregistered from event: ", id)
-              })
-            }}
+            onClick={() => { fns.unregister(id) }}
           > unregister </Button>
         </div>
       )

--- a/ui/src/components/event-status-buttons.tsx
+++ b/ui/src/components/event-status-buttons.tsx
@@ -1,0 +1,85 @@
+import { Backend, EventId, EventStatus } from "@/backend"
+import { Button } from "@/components/ui/button"
+
+type FnProps = {
+  register: Backend["register"]
+  unregister: Backend["unregister"]
+}
+
+const ButtonSwitch: React.FC<
+  {
+    id: EventId,
+    status: EventStatus
+  }
+  & FnProps
+> = ({ id, status, ...fns }) => {
+  switch (status) {
+    case "invited":
+    case "unregistered":
+      return (
+        <div className="flex-auto">
+          <Button
+            className="h-full w-full"
+            onClick={
+              () => {
+                fns.register(id)
+              }}
+          > register </Button>
+        </div>
+      )
+    case "registered":
+      // TODO: add a slide-out thingy that says: are you sure?
+      return (
+        <div className="flex-auto">
+          <Button
+            className="h-full w-full hover:bg-red-900"
+            onClick={() => {
+              fns.unregister(id).then(() => {
+                console.log("unregistered from event: ", id)
+              })
+            }}
+          > unregister </Button>
+        </div>
+      )
+    case "attended":
+      return (
+        <div className="flex-auto">
+          <Button
+            className="h-full w-full hover:bg-emerald-900"
+            disabled
+          > attended </Button>
+        </div>
+      )
+    case "requested":
+      return (
+        <div className="flex-auto">
+          <Button
+            disabled
+            className="h-full w-full hover:bg-stone-900"
+          > requested </Button>
+        </div>
+      )
+    default:
+      console.error(`unexpected evt status: ${status}`)
+      return (<div></div>)
+  }
+}
+
+
+const EventStatusButtons: React.FC<
+  {
+    id: EventId,
+    status: EventStatus
+  }
+  & FnProps
+> = ({ id, status, ...fns }) => {
+  return (
+    <ButtonSwitch
+      id={id}
+      status={status}
+      {...fns}
+    />
+  )
+}
+
+export default EventStatusButtons;

--- a/ui/src/components/navbar.tsx
+++ b/ui/src/components/navbar.tsx
@@ -1,15 +1,31 @@
-import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger, } from "@/components/ui/navigation-menu"
+import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuList, NavigationMenuTrigger, } from "@/components/ui/navigation-menu"
 import { Link } from "react-router-dom"
 import ProfileDialog from "./profile-dialog"
 import { useEffect, useState } from "react"
 import { Button } from "./ui/button"
-import { ChevronLeft, ChevronLeftSquare, ChevronUp, Edit, Menu, User, Users } from "lucide-react"
+import { ChevronLeft, User, } from "lucide-react"
 import { flipBoolean } from "@/lib/utils"
-import { Backend, Profile, } from "@/backend"
+import { Backend, EventAsGuest, Profile } from "@/backend"
 import { SlideDownAndReveal } from "./sliders"
+import EventStatusButtons from "./event-status-buttons"
 
+type Props = {
+  event: EventAsGuest,
+  patp: string,
+  profile: Profile,
+  editProfileField: Backend["editProfileField"]
+  register: Backend["register"]
+  unregister: Backend["unregister"]
+}
 
-export default function NavBar(props: { eventName: string, host: string, patp: string, profile: Profile, editProfileField: Backend["editProfileField"] }) {
+const NavBar: React.FC<Props> = (
+  {
+    event: { details: { id: { name: eventName, ship: eventHost } }, status: eventStatus, ...eventRest },
+    patp,
+    profile,
+    ...fns
+  }) => {
+
   const [openProfile, setOpenProfile] = useState(false)
   const [width, setWidth] = useState<number>(window.innerWidth);
   const [openMenu, setOpenMenu] = useState(false);
@@ -39,12 +55,21 @@ export default function NavBar(props: { eventName: string, host: string, patp: s
           <ProfileDialog
             onOpenChange={setOpenProfile}
             open={openProfile}
-            patp={props.patp}
-            profileFields={props.profile}
-            editProfileField={props.editProfileField}
+            patp={patp}
+            profileFields={profile}
+            editProfileField={fns.editProfileField}
           />
         </NavigationMenuItem>
-        <NavigationMenuItem className="grow text-center"> {props.eventName || "event"} </NavigationMenuItem>
+        <NavigationMenuItem className="fixed left-12">
+          <EventStatusButtons
+            id={{ ship: eventHost, name: eventName }}
+            status={eventStatus}
+            register={fns.register}
+            unregister={fns.unregister}
+
+          />
+        </NavigationMenuItem>
+        <NavigationMenuItem className="grow text-center"> {eventName || "event"} </NavigationMenuItem>
         {
           isMobile
             ?
@@ -57,7 +82,7 @@ export default function NavBar(props: { eventName: string, host: string, patp: s
                 <ul className="grid gap-3 m-2 justify-items-end">
                   <li className="row row-span-3">
                     <Button>
-                      <Link to={`/apps/live/event/${props.host}/${props.eventName}`}> event home </Link>
+                      <Link to={`/apps/live/event/${eventHost}/${eventName}`}> event home </Link>
                     </Button>
                   </li>
                   <li className="row row-span-3">
@@ -97,7 +122,7 @@ export default function NavBar(props: { eventName: string, host: string, patp: s
               <NavigationMenuContent>
                 <ul className="grid gap-3 p-4  md:w-[400px] lg:w-[500px] ">
                   <li className="row row-span-3">
-                    <Link to={`/apps/live/event/${props.host}/${props.eventName}`}> event home </Link>
+                    <Link to={`/apps/live/event/${eventHost}/${eventName}`}> event home </Link>
                   </li>
                   <li className="row row-span-3">
                     <Link to="attendees"> attendees </Link>
@@ -117,9 +142,5 @@ export default function NavBar(props: { eventName: string, host: string, patp: s
     </NavigationMenu >
   )
 }
-//   <NavigationMenuItem>
-//     <NavigationMenuTrigger>Item One</NavigationMenuTrigger>
-//     <NavigationMenuContent>
-//       <NavigationMenuLink>Link</NavigationMenuLink>
-//     </NavigationMenuContent>
-//   </NavigationMenuItem>
+
+export default NavBar;

--- a/ui/src/components/navbar.tsx
+++ b/ui/src/components/navbar.tsx
@@ -20,7 +20,11 @@ type Props = {
 
 const NavBar: React.FC<Props> = (
   {
-    event: { details: { id: { name: eventName, ship: eventHost } }, status: eventStatus, ...eventRest },
+    event: {
+      details: { id: { name: eventName, ship: eventHost } },
+      status: eventStatus,
+      ...eventRest
+    },
     patp,
     profile,
     ...fns

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/ui/src/pages/context.ts
+++ b/ui/src/pages/context.ts
@@ -1,8 +1,8 @@
 import { createContext } from "react";
-import { Event, Profile } from "@/backend";
+import { Event, EventDetails, Profile } from "@/backend";
 
 interface IndexCtx {
-  events: Event[]
+  events: EventDetails[]
   patp: string;
   profile: Profile;
 }

--- a/ui/src/pages/event/attendees.tsx
+++ b/ui/src/pages/event/attendees.tsx
@@ -22,8 +22,8 @@ export function AttendeesPage(props: { backend: Backend }) {
       <AttendeeList
         attendees={ctx.attendees}
         profiles={ctx.profiles}
-        match={async (patp: string) => await props.backend.match(ctx.details.id, patp)}
-        unmatch={async (patp: string) => await props.backend.unmatch(ctx.details.id, patp)}
+        match={async (patp: string) => await props.backend.match(ctx.event.details.id, patp)}
+        unmatch={async (patp: string) => await props.backend.unmatch(ctx.event.details.id, patp)}
         editProfileField={props.backend.editProfileField}
       />
     </div>

--- a/ui/src/pages/event/context.ts
+++ b/ui/src/pages/event/context.ts
@@ -1,29 +1,32 @@
 import { createContext } from "react";
-import { Session, Event, Profile, Attendee } from "@/backend";
+import { Session, Event, Profile, Attendee, EventAsGuest } from "@/backend";
 
 interface EventCtx {
-  details: Event
+  event: EventAsGuest
   attendees: Attendee[];
   profiles: Profile[];
 }
 
 function newEmptyCtx(): EventCtx {
   return {
-    details: {
-      id: {
-        ship: "",
-        name: ""
+    event: {
+      details: {
+        id: {
+          ship: "",
+          name: ""
+        },
+        location: "",
+        startDate: new Date(0),
+        endDate: new Date(0),
+        description: "",
+        timezone: "",
+        kind: "public",
+        group: "",
+        latch: "open",
+        sessions: [] as Session[],
       },
       status: "invited",
-      location: "",
-      startDate: new Date(0),
-      endDate: new Date(0),
-      description: "",
-      timezone: "",
-      kind: "public",
-      group: "",
-      latch: "open",
-      sessions: [] as Session[],
+      secret: "",
     },
     profiles: [] as Profile[],
     attendees: [] as Attendee[],

--- a/ui/src/pages/event/context.ts
+++ b/ui/src/pages/event/context.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { Session, Event, Profile, Attendee, EventAsGuest } from "@/backend";
+import { Session, Profile, Attendee, EventAsGuest } from "@/backend";
 
 interface EventCtx {
   event: EventAsGuest

--- a/ui/src/pages/event/details.tsx
+++ b/ui/src/pages/event/details.tsx
@@ -11,16 +11,25 @@ export function EventDetails() {
     throw Error("context is null")
   }
 
-  const evt = ctx.details
+  const {
+    event: {
+      details: {
+        id: { ship, name },
+        startDate,
+        endDate,
+        description
+      }
+    }
+  } = ctx
 
   return (
     <div className="max-w-2lg space-y-6 py-20 text-center">
       <div className="grid items-justify mx-12 md:mx-24 gap-y-6">
-        <h1 className="text-xl font-semibold"> {ctx.details.id.name} </h1>
-        <h1 className="text-xl italics"> hosted by {ctx.details.id.ship} </h1>
-        <h1 className="text-xl italics"> starts: {ctx.details.startDate.toString()} </h1>
-        <h1 className="text-xl italics"> ends: {ctx.details.endDate.toString()} </h1>
-        <h1 className="text-xl text-justify font-normal"> {ctx.details.description} </h1>
+        <h1 className="text-xl font-semibold"> {name} </h1>
+        <h1 className="text-xl italics"> hosted by {ship} </h1>
+        <h1 className="text-xl italics"> starts: {startDate.toString()} </h1>
+        <h1 className="text-xl italics"> ends: {endDate.toString()} </h1>
+        <h1 className="text-xl text-justify font-normal"> {description} </h1>
         <div className="flex justify-between">
           <Button className="w-fit-content">
             {/* if we use these Links without reloadDocument prop set they make

--- a/ui/src/pages/event/index.tsx
+++ b/ui/src/pages/event/index.tsx
@@ -7,7 +7,6 @@ import { EventContext, EventCtx, newEmptyCtx } from './context';
 import { IndexContext, IndexCtx, newEmptyIndexCtx } from '../context';
 
 import { Backend, EventId, eventIdsEqual, Profile } from '@/backend'
-import { resolve } from 'path';
 
 interface EventParams {
   hostShip: string,
@@ -49,7 +48,8 @@ async function buildContextData({ hostShip, name }: EventParams, backend: Backen
   const evtId: EventId = { ship: hostShip, name: name }
   // we could also do away with this backend call here
   // and add a prop to pass EventDetails from the main page
-  evt.details = await backend.getEvent(evtId)
+  evt.details = await backend.getRecord(evtId)
+  console.log(evt.details)
   evt.attendees = await backend.getAttendees(evtId);
   evt.profiles = await backend.getProfiles(evtId);
 
@@ -93,14 +93,14 @@ export function EventIndex(props: { backend: Backend }) {
         onEvent: (evt) => {
           console.log("%live event: ", evt)
 
-          setEventCtx(({ details: _details, ...rest }) => {
-            if (eventIdsEqual(eventContext.details.id, evt.event.id)) {
+          setEventCtx(({ event: { details, ...restEvent }, ...rest }) => {
+            if (eventIdsEqual(eventContext.event.details.id, evt.event.id)) {
               return {
-                details: evt.event,
+                event: { details: evt.event, ...restEvent },
                 ...rest
               }
             }
-            return { details: _details, ...rest }
+            return { event: { details, ...restEvent }, ...rest }
           })
 
         },
@@ -119,7 +119,7 @@ export function EventIndex(props: { backend: Backend }) {
           }
         })
       })
-    console.log(eventContext)
+    console.log("ctx",eventContext)
 
 
 
@@ -133,8 +133,8 @@ export function EventIndex(props: { backend: Backend }) {
     <EventContext.Provider value={eventContext}>
       <div className="grid size-full" >
         <NavBar
-          eventName={eventContext.details.id.name}
-          host={eventContext.details.id.ship}
+          eventName={eventContext.event!.details.id.name}
+          host={eventContext.event!.details.id.ship}
           profile={ownProfileFields}
           patp={window.ship}
           editProfileField={props.backend.editProfileField}

--- a/ui/src/pages/event/schedule.tsx
+++ b/ui/src/pages/event/schedule.tsx
@@ -40,7 +40,7 @@ export function SchedulePage() {
   const [activeDate, setActiveDate] = useState<Date>(new Date(0))
 
   useEffect(() => {
-    setDates(makeDatesMap(ctx.details.sessions))
+    setDates(makeDatesMap(ctx.event.details.sessions))
   }, [ctx])
 
   useEffect(() => {
@@ -57,7 +57,7 @@ export function SchedulePage() {
         currentDate={getCurrentDate(dates)}
       />
       <SessionList
-        sessions={ctx.details.sessions.filter(({ startTime }) => startTime.getDay() === activeDate.getDay())} />
+        sessions={ctx.event.details.sessions.filter(({ startTime }) => startTime.getDay() === activeDate.getDay())} />
     </div>
   )
 }

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Backend, Profile, Event, eventIdsEqual, EventAsHost, EventAsGuest } from "@/backend";
+import { Backend, Profile, eventIdsEqual, EventAsHost, EventAsGuest } from "@/backend";
 import EventList from "@/components/event-list";
 import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from "@/components/ui/navigation-menu";
 import { useEffect, useState } from "react";
@@ -137,15 +137,11 @@ const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
           <TabsContent value="eventsAsHost">
             <EventList
               details={eventsAsHost.map((evt) => evt.details)}
-              register={backend.register}
-              unregister={backend.unregister}
             />
           </TabsContent>
           <TabsContent value="eventsAsGuest">
             <EventList
               details={eventsAsGuest.map((evt) => evt.details)}
-              register={backend.register}
-              unregister={backend.unregister}
             />
           </TabsContent>
         </Tabs>

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -64,16 +64,14 @@ const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
     let liveSubId: number
 
     backend.subscribeToLiveEvents({
-      onEvent: (evt) => {
-        console.log("%live event: ", evt)
+      onEvent: (updateEvent) => {
         // TODO: do we get updates on host events too?
         setEventsAsGuest((oldEvts) => {
-          return oldEvts.map(({ details, ...rest }) => {
-            if (eventIdsEqual(evt.event.id, details.id)) {
-              console.log("found")
-              return { details: evt.event, ...rest }
+          return oldEvts.map((oldEvt) => {
+            if (eventIdsEqual(updateEvent.event.details.id, oldEvt.details.id)) {
+              return updateEvent.event
             }
-            return { details, ...rest }
+            return oldEvt
           })
         })
       },

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Backend, Profile, Event, eventIdsEqual } from "@/backend";
+import { Backend, Profile, Event, eventIdsEqual, EventAsHost, EventAsGuest } from "@/backend";
 import EventList from "@/components/event-list";
 import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from "@/components/ui/navigation-menu";
 import { useEffect, useState } from "react";
@@ -7,14 +7,15 @@ import { User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ProfileDialog from "@/components/profile-dialog";
 import { flipBoolean } from "@/lib/utils";
-import { unsubscribe } from "diagnostics_channel";
+import { Tabs, TabsList, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 
 const emptyCtx = newEmptyIndexCtx()
 
 async function buildContextData(ourShip: string, backend: Backend) {
 
   const ctx = emptyCtx
-  ctx.events = await backend.getEvents()
+  ctx.events = await backend.getRecords()
+    .then((events) => events.map(evt => evt.details))
 
   ctx.patp = ourShip
   const profile = await backend.getProfile(ourShip)
@@ -26,13 +27,10 @@ async function buildContextData(ourShip: string, backend: Backend) {
 }
 
 const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
-  const [events, setEvents] = useState<Event[]>([])
+  const [eventsAsGuest, setEventsAsGuest] = useState<EventAsGuest[]>([])
+  const [eventsAsHost, setEventsAsHost] = useState<EventAsHost[]>([])
   const [ownProfileFields, setOwnProfileFields] = useState<Profile>({})
   const [openProfile, setOpenProfile] = useState(false)
-
-
-
-
 
   // window.urbit.subscribe({
   //   app: "live",
@@ -43,7 +41,8 @@ const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
   // }).then(() => {console.log("subscribed to live")})
 
   useEffect(() => {
-    backend.getEvents().then(setEvents);
+    backend.getRecords().then(setEventsAsGuest);
+    backend.getEvents().then(setEventsAsHost);
 
     console.log("trying match")
 
@@ -67,13 +66,14 @@ const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
     backend.subscribeToLiveEvents({
       onEvent: (evt) => {
         console.log("%live event: ", evt)
-        setEvents((oldEvts) => {
-          return oldEvts.map((oldEvt) => {
-            if (eventIdsEqual(evt.event.id, oldEvt.id)) {
+        // TODO: do we get updates on host events too?
+        setEventsAsGuest((oldEvts) => {
+          return oldEvts.map(({ details, ...rest }) => {
+            if (eventIdsEqual(evt.event.id, details.id)) {
               console.log("found")
-              return evt.event
+              return { details: evt.event, ...rest }
             }
-            return oldEvt
+            return { details, ...rest }
           })
         })
       },
@@ -128,12 +128,28 @@ const Index: React.FC<{ backend: Backend }> = ({ backend }) => {
       </NavigationMenu>
 
       <div className="grid justify-center w-full space-y-6 py-20 text-center">
-        <h1 className="text-3xl italic">*events*</h1>
-        <EventList
-          events={events}
-          register={backend.register}
-          unregister={backend.unregister}
-        />
+        <h1 className="text-3xl italic">events</h1>
+        <Tabs defaultValue="eventsAsGuest" className="w-[400px]">
+          <TabsList>
+            <TabsTrigger value="eventsAsHost">you're hosting</TabsTrigger>
+            <TabsTrigger value="eventsAsGuest">you can participate</TabsTrigger>
+          </TabsList>
+          <TabsContent value="eventsAsHost">
+            <EventList
+              details={eventsAsHost.map((evt) => evt.details)}
+              register={backend.register}
+              unregister={backend.unregister}
+            />
+          </TabsContent>
+          <TabsContent value="eventsAsGuest">
+            <EventList
+              details={eventsAsGuest.map((evt) => evt.details)}
+              register={backend.register}
+              unregister={backend.unregister}
+            />
+          </TabsContent>
+        </Tabs>
+
       </div>
     </div>
   )

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -11,17 +11,25 @@ import { urbitPlugin } from './vendor/vite-urbit-plugin';
 // import { urbitPlugin } from '@urbit/vite-plugin-urbit';
 
 
+
 // https://vitejs.dev/config/
-export default ({ mode }) => {
-  Object.assign(process.env, loadEnv(mode, process.cwd()));
-  const SHIP_URL = process.env.SHIP_URL || process.env.VITE_SHIP_URL || 'http://localhost:8080';
-  console.log(SHIP_URL);
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, '')
 
-  const inDev = process.env.NODE_ENV === 'development';
+  const SHIP_URL = env.SHIP_URL || env.VITE_SHIP_URL || 'http://localhost:8080';
+  const flags = {
+    inDev: mode === 'development',
+    enablePwa: env.ENABLE_PWA_IN_DEV === "true"
+  }
 
-  return defineConfig({
+  if (flags.inDev) {
+    console.log("running with env: ", env)
+    console.log("flags: ", flags)
+  }
+
+  return {
     plugins: [
-      urbitPlugin({ base: 'live', target: SHIP_URL, development: inDev }),
+      urbitPlugin({ base: 'live', target: SHIP_URL, development: flags.inDev }),
       reactRefresh(),
       VitePWA({
         registerType: 'autoUpdate',
@@ -54,7 +62,7 @@ export default ({ mode }) => {
           ],
         },
         devOptions: {
-          enabled: inDev
+          enabled: flags.inDev && flags.enablePwa
         },
       }),
     ],
@@ -63,5 +71,5 @@ export default ({ mode }) => {
         "@": path.resolve(__dirname, "./src"),
       },
     },
-  });
-};
+  }
+});


### PR DESCRIPTION
refinements:
+ Timeline: visually distinguish between record and event
	+ Should see our record status on event page and include the status change button in here instead of on the timeline card.
		+ The entire event/record tiles on the Timeline page should be clickable, opening the event details.

extras:
 - added .env flag to disable PWA in development
 - refactored Event type in backend.ts to EventAsGuest, EventAsHost, EventDetails