### PR TITLE
Pal tagging

### DIFF
--- a/desk/app/matcher.hoon
+++ b/desk/app/matcher.hoon
@@ -5,7 +5,7 @@
 ::
 |%
 ::
-+$  versioned-state  $%(state-0)
++$  versioned-state  $%(state-0 state-1)
 ::
 +$  state-0
   $:  %0
@@ -17,13 +17,24 @@
       pub-peers=_(mk-pubs live-peers ,[%peers @ @ ~])  :: publications
   ==
 ::
++$  state-1
+  $:  %1
+      profiles=(mip ship term entry)                   :: contact info
+      peers=(mip id:live ship status)                  :: our relation to a peer
+      matches=(mip id:live ship (list ship))           :: host pov: matches
+      reaches=(mip id:live ship (list ship))           :: host pov: match tries
+      sub-peers=_(mk-subs live-peers ,[%peers @ @ ~])  :: subscriptions
+      pub-peers=_(mk-pubs live-peers ,[%peers @ @ ~])  :: publications
+      add-pals=?                                       :: add %match peers as pal
+  ==
+::
 +$  card  card:agent:gall
 ::
 --
 ::
 %+  verb  |
 %-  agent:dbug
-=|  state-0
+=|  state-1
 =*  state  -
 ::
 ^-  agent:gall
@@ -94,7 +105,7 @@
                     -:!>(*fail:da)
                   ==
 ::
-++  emit  |=(=card ~&(card cor(dek [card dek])))
+++  emit  |=(=card cor(dek [card dek]))
 ++  emil  |=(lac=(list card) cor(dek (welp lac dek)))
 ++  abet  ^-((quip card _state) [(flop dek) state])
 ++  bran  |=(=tape (weld "%matcher: " tape))
@@ -128,8 +139,20 @@
 ++  load
   |=  =vase
   ^+  cor
-  ?>  ?=([%0 *] q.vase)
-  cor(state !<(state-0 vase))
+  =+  !<(ole=versioned-state vase)
+  ?-    -.ole
+      %1  cor(state ole)
+      %0
+    %=  cor
+      state  :*  %1
+                 profiles.ole
+                 peers.ole
+                 matches.ole
+                 reaches.ole
+                 sub-peers.ole
+                 pub-peers.ole
+                 %|
+  ==  ==    ==
 ::
 ++  watch
   |=  pol=(pole knot)
@@ -157,6 +180,7 @@
   =;  =demand
     ``[%matcher-demand !>(demand)]
   ?+    pol  ~|(invalid-scry-path+pol !!)
+      [%u %pals %add ~]  [%add-pals add-pals]
       [%x %profile ship=@ ~]
     :-  %profile
     ?~  mp=(~(get by profiles) (slav %p ship:pol))  ~
@@ -271,9 +295,12 @@
       %matcher-deed
     =+  !<(=deed vase)
     ?-  -.deed
-      %edit-profile    (edit-profile term.deed entry.deed)
-      %profile-diff    (update-peer-profile p.deed)
-      %shake           (~(shake pe id.deed ship.deed) act.deed)
+        %edit-profile    (edit-profile term.deed entry.deed)
+        %profile-diff    (update-peer-profile p.deed)
+        %shake           (~(shake pe id.deed ship.deed) act.deed)
+        %add-pals
+      =.  cor  (local-update [%add-pals p.deed])
+      cor(add-pals p.deed)
     ==
   ::
       %matcher-dictum
@@ -644,15 +671,17 @@
       culp
     ?.  (~(has bi peers) id culp)  cor
     =?  cor  ?~(status | ?=(%match u.status))
-      =?  cor  .^(? %gu (weld (base-path %pals) /$))
-        (add-pal culp)
+      =?  cor  ?&  add-pals
+                   .^(? %gu (weld (base-path %pals) /$))
+               ==
+        (poke-pals culp)
       (send-profile %whole culp)
     =.  cor
       (local-update [%match culp status])
     cor(peers (~(put bi peers) id culp status))
-    ::  +add-pal: send a %meet poke to %pals with event title as tag
+    ::  +poke-pals: send a %meet poke to %pals with event title as tag
     ::
-    ++  add-pal
+    ++  poke-pals
       |=  =ship
       ^+  cor
       =/  =demand:live

--- a/desk/app/matcher.hoon
+++ b/desk/app/matcher.hoon
@@ -644,43 +644,87 @@
       culp
     ?.  (~(has bi peers) id culp)  cor
     =?  cor  ?~(status | ?=(%match u.status))
+      =?  cor  .^(? %gu (weld (base-path %pals) /$))
+        (add-pal culp)
       (send-profile %whole culp)
     =.  cor
       (local-update [%match culp status])
     cor(peers (~(put bi peers) id culp status))
+    ::  +add-pal: send a %meet poke to %pals with event title as tag
+    ::
+    ++  add-pal
+      |=  =ship
+      ^+  cor
+      =/  =demand:live
+        %+  live-scry  %gx
+        ?:  =(ship.id our.bowl)
+          /event/(scot %p ship.id)/(scot %tas name.id)
+        /record/(scot %p ship.id)/(scot %tas name.id)/(scot %p our.bowl)
+      ?>  ?:  =(ship.id our.bowl)
+            ?=(%event -.demand)
+          ?=(%record -.demand)
+      ?~  p.demand  cor
+      =/  title=@ta
+        =/  =cord
+          =-  title.info.-
+          ?:  ?=(%event -.demand)
+            `event-1:live`u.p.demand
+          ?>  ?=(%record -.demand)
+          `record-1:live`u.p.demand
+        ?~(a=cord (scot %tas name.id) (knot-safe a))
+      =/  =cage
+        pals-command+!>(`command:pals`[%meet ship (silt ~[title])])
+      (emit (make-act /pals/add our.bowl %pals cage))
+    ::  +knot-safe: make a raw cord knot safe
+    ::
+    ++  knot-safe
+      |=  =cord
+      %-  crip
+      =;  =tape
+        ?.  (~(has in (silt "0123456789")) (snag 0 tape))
+          tape
+        (weld "n" tape)
+      %+  turn  (cass (trip cord))
+      |=  a=@t
+      =/  special
+        (silt " ~`!@#$%^&*()-=_+[]\{}'\\:;\",.<>?")
+      ?:((~(has in special) a) '-' a)
+    --
   ::  +shake: core matching arm
   ::
   ++  shake
     |=  act=?
     |^  ^+  cor
-        ?:  =(our.bowl src.bowl)
-          ?:  =(our.bowl culp)
-            ~&(>>> (bran "cannot match with ourselves") cor)
-          ?.  (~(has bi peers) id culp)
-            ~&  >>>
-              (bran "{<culp>} is not on the guest list for event: {<id>}")
-            cor
-          ?:  =(ship.id our.bowl)
-            ::  as host
-            ::
-            ?:(act init-reach remove-reach)
-          ::  as a guest
-          ::
-          =/  =cage
-            matcher-deed+!>(`deed`[%shake id culp act])
-          %-  emit
-          (make-act /shake/(scot %p culp) ship.id dap.bowl cage)
-        :: received from a guest, wanting us, the host, to fwd along
+    ?:  =(our.bowl src.bowl)
+      ?:  =(our.bowl culp)
+        ~&(>>> (bran "cannot match with ourselves") cor)
+      ?.  (~(has by peers) id)
+        ~&(>>> (bran "you don't have access to guest list for {<id>}") cor)
+      ?.  (~(has bi peers) id culp)
+        ~&  >>>
+          (bran "{<culp>} is not on the guest list for event: {<id>}")
+        cor
+      ?:  =(ship.id our.bowl)
+        ::  as host
         ::
-        ?.  =(ship.id our.bowl)  cor
-        ::  they cannot match with themselves
-        ::
-        ?:  =(src.bowl culp)  cor
-        ::  both ships in question must be in our peers mip
-        ::
-        ?.  &((~(has bi peers) id src.bowl) (~(has bi peers) id culp))
-          cor
         ?:(act init-reach remove-reach)
+      ::  as a guest
+      ::
+      =/  =cage
+        matcher-deed+!>(`deed`[%shake id culp act])
+      %-  emit
+      (make-act /shake/(scot %p culp) ship.id dap.bowl cage)
+    :: received from a guest, wanting us, the host, to fwd along
+    ::
+    ?.  =(ship.id our.bowl)  cor
+    ::  they cannot match with themselves
+    ::
+    ?:  =(src.bowl culp)  cor
+    ::  both ships in question must be in our peers mip
+    ::
+    ?.  &((~(has bi peers) id src.bowl) (~(has bi peers) id culp))
+      cor
+    ?:(act init-reach remove-reach)
     ::  +mod-reaches: modify the reaches mip
     ::
     ++  mod-reaches

--- a/desk/app/matcher.hoon
+++ b/desk/app/matcher.hoon
@@ -94,7 +94,7 @@
                     -:!>(*fail:da)
                   ==
 ::
-++  emit  |=(=card cor(dek [card dek]))
+++  emit  |=(=card ~&(card cor(dek [card dek])))
 ++  emil  |=(lac=(list card) cor(dek (welp lac dek)))
 ++  abet  ^-((quip card _state) [(flop dek) state])
 ++  bran  |=(=tape (weld "%matcher: " tape))

--- a/desk/lib/matcher-json.hoon
+++ b/desk/lib/matcher-json.hoon
@@ -9,6 +9,7 @@
   %-  of
   :~  edit-profile+(ot ~[term+(se %tas) entry+so:dejs-soft:format])
       shake+de-shake
+      add-pals+bo
   ==
   ::
   ++  de-shake
@@ -36,6 +37,7 @@
   |=  upd=update
   ^-  ^json
   ?-    -.upd
+      %add-pals  (frond ['addPals' b+p.upd])
       %match
     %-  pairs
     :~  ['ship' s+(scot %p ship.upd)]
@@ -59,6 +61,7 @@
       %peer-status  !!
       %matches      !!
       %reaches      !!
+      %add-pals     ['addPals' b+p.demand]
       %peers        ['peers' (en-peers p.demand)]
       %profile      ['profile' (en-profile p.demand)]
       %profiles     ['allProfiles' (en-all-profiles p.demand)]

--- a/desk/sur/matcher.hoon
+++ b/desk/sur/matcher.hoon
@@ -23,15 +23,17 @@
 ::  $deed: host or guest action
 ::
 +$  deed
-  $%  [%profile-diff p=(map term entry)]     :: update peer profile
-      [%edit-profile =term =entry]           :: edit profile
-      [%shake =id:live =ship act=?]          :: initiate a new peer status
+  $%  [%profile-diff p=(map term entry)]  :: update peer profile
+      [%edit-profile =term =entry]        :: edit profile
+      [%shake =id:live =ship act=?]       :: initiate a new peer status
+      [%add-pals p=?]                     :: add matched peers as pal
   ==
 ::  $update: local subscription changes
 ::
 +$  update
   $%  [%match =ship =status]                       :: match change
       [%profile =ship fields=(list [term entry])]  :: profile change
+      [%add-pals p=?]                              :: %pals toggle change
   ==
 ::  $demand: scry api
 ::
@@ -42,5 +44,6 @@
       [%peers p=(map ship status)]                  :: peer statuses by event
       [%matches p=(map ship (list ship))]           :: all matches for an event
       [%reaches p=(map ship (list ship))]           :: all reaches for an event
+      [%add-pals p=?]                               :: are matches added as pal
   ==
 --

--- a/desk/sur/pals.hoon
+++ b/desk/sur/pals.hoon
@@ -1,0 +1,41 @@
+::  pals: manual neighboring
+::
+|%
++$  records  ::  local state
+  $:  outgoing=(jug ship @ta)
+      incoming=(set ship)
+    ::
+      ::  receipts: for all outgoing, status
+      ::
+      ::    if ship not in receipts,  poke awaiting ack
+      ::    if ship present as true,  poke acked positively
+      ::    if ship present as false, poke acked negatively
+      ::
+      receipts=(map ship ?)
+  ==
+::
++$  gesture  ::  to/from others
+  $%  [%hey ~]
+      [%bye ~]
+  ==
+::
++$  command  ::  from ourselves
+  $%  [%meet =ship in=(set @ta)]  ::  empty set allowed
+      [%part =ship in=(set @ta)]  ::  empty set implies un-targeting
+  ==
+::
++$  effect  ::  to ourselves
+  $%  target-effect
+      leeche-effect
+  ==
+::
++$  target-effect
+  $%  [%meet =ship]  ::  hey to target
+      [%part =ship]  ::  bye to target
+  ==
+::
++$  leeche-effect
+  $%  [%near =ship]  ::  hey from leeche
+      [%away =ship]  ::  bye from leeche
+  ==
+--

--- a/todo.md
+++ b/todo.md
@@ -17,6 +17,7 @@ key:
   - event search
       - somewhere on this page we can see our previous search (can be scried from backend state)
   - guest should see their status and date it occured
+  - add %pal connection language on the Connections page: "ships you match with will be added as %pals"
   - there's brief delay when clicking into an event which feels like a crash because we get a blank page until the data appears. It's probably the time it takes for the scry to retrieve the data, but the user should know the app is still functioning. I think we should add a loading spinner in the middle of the page, or somewhere where it's obvious, so the user knows the app is doing something. This should appear anytime the frontend is scrying for data or knows it's waiting for an update from the backend (e.g. poking another ship and waiting for some data change).
   - on mobile: the frame for the event page is a bit wide; shouldn't have to scroll to the right/left. the boxes and text should be flush with the screen.
   - Event/session descriptions should recognize breaks, links, and images

--- a/todo.md
+++ b/todo.md
@@ -17,12 +17,16 @@ key:
   - event search
       - somewhere on this page we can see our previous search (can be scried from backend state)
   - guest should see their status and date it occured
-  - add %pal connection language on the Connections page: "ships you match with will be added as %pals"
+  - add %pal toggle on profile form
+      - 'Automatically add ships you match with as %pals and include the event title as a tag. This change will only take effect on future matches.'
   - there's brief delay when clicking into an event which feels like a crash because we get a blank page until the data appears. It's probably the time it takes for the scry to retrieve the data, but the user should know the app is still functioning. I think we should add a loading spinner in the middle of the page, or somewhere where it's obvious, so the user knows the app is doing something. This should appear anytime the frontend is scrying for data or knows it's waiting for an update from the backend (e.g. poking another ship and waiting for some data change).
   - on mobile: the frame for the event page is a bit wide; shouldn't have to scroll to the right/left. the boxes and text should be flush with the screen.
   - Event/session descriptions should recognize breaks, links, and images
   - need to remove the avatar, patp, and nickname from the profile. the patp should just be next to the avatar image, or if a nickname is set in parethesis next to it.
   - @p's show up without the ~ prepended.
+  - Respect calm engine settings
+    - frontend just needs to scry this out. either show/hide the avatar and/or the nickname
+
 
 
 
@@ -37,9 +41,10 @@ key:
             + when scry result comes in, extract name from path
             + test
             + consolidate result update into one arm and call at each instance
-  - get-our-case is failing after second time we try to pass something through +change-info
-	- Event-level tagging in %pals
-  - Respect calm engine settings
+  + get-our-case is failing after second time we try to pass something through +change-info
+	+ Event-level tagging in %pals
+    + toggle %pals setting
+  - include a changelog.txt in desk
 
 
 


### PR DESCRIPTION
As a way to keep track of friend connections over time, `%matcher` includes an option to add peers you match with as %pals with an event title tag included. 

Functionally, this just means `%matcher` will send a `%meet` poke to `%pals` with the event title as tag if `$add-pals` state is positive. 